### PR TITLE
Replace laravel logger with custom logger

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -2,6 +2,8 @@
 
 namespace LostInTranslation;
 
+use Monolog\Logger as Monolog;
+use Illuminate\Log\Writer;
 use Illuminate\Translation\Translator as BaseTranslator;
 use LostInTranslation\Events\MissingTranslationFound;
 use LostInTranslation\Exceptions\MissingTranslationException;
@@ -67,7 +69,7 @@ class Translator extends BaseTranslator {
     protected function logMissingTranslation($key, $replace, $locale, $fallback)
     {
         if (! $this->logger) {
-            $this->logger = logger();
+            $this->logger = new Writer(new Monolog('lost-in-translation'));
             $this->logger->useFiles(storage_path('logs/lost-in-translation.log'));
         }
 


### PR DESCRIPTION
This PR solves #1.

The Laravel helper `logger()` returns the [Logger singleton](https://github.com/laravel/framework/blob/5.5/src/Illuminate/Foundation/helpers.php#L517) as defined by Laravel's `LogServiceProvider`. When adding a monolog handler to this log, it will make Monolog write to Laravel's default log _and_ the new log. To circumvent this you could pop all handlers from the underlying Monolog instance before adding your own, though I am uncertain what kind of repercussions that would have on the rest of the logging functionality.

As such I went with creating a new logger altogether. Laravel's handler uses a Monolog channel name based on the app environment, but I think hardcoding one for a dedicated log file is fine as well.

Now, since this is wanted behavior and not covered by any of the tests, I recommend to create another one to test for it:
1. Make log path configurable (?)
2. Include a virtual file stream package for testing (such as `adlawson/vfs`)
3. Overwrite the `storage_path` helper to aim at a virtual file stream path, so that laravel's logs get posted in it
4. Configure this package's log path (for testing) to aim at the virtual file stream also
5. Force a lost-in-translation notice to be logged
6. Assert the laravel log to be empty and the lost-in-translation log to have content

If you agree with this plan of action I'll gladly give it a shot to implement this myself.