### PR TITLE
Translations with replaced keys did not trigger a MissingTranslationException

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -54,7 +54,7 @@ class Translator extends BaseTranslator
         $translation = parent::get($key, $replace, $locale, $fallback);
 
         // The "translation" is unchanged from the key.
-        if ($translation === $key) {
+        if ($translation === $key || !isset($this->loaded['*']['*'][$locale ?: $this->locale][$key])) {
             // Log the missing translation.
             if (config('lostintranslation.log')) {
                 $this->logMissingTranslation($key, $replace, $locale, $fallback);


### PR DESCRIPTION
Ex:
**Translated Keys:**
"strike_number_1" : "Strike One"

**Key not translated and not flagged**
$strikes = 1;
__('He makes contact with the ball, but not enough to get a hit. Foul tip. :strike_number.', [
  'strike_number' => __('strike_number_' + $strikes)
]);

The current check will compare
"He makes contact with the ball, but not enough to get a hit. Foul tip. :strike_number."
with
"He makes contact with the ball, but not enough to get a hit. Foul tip. Strike One"
and it will not flag the key as not translated.